### PR TITLE
Add asynchronous messaging mechanism.

### DIFF
--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -3,6 +3,7 @@ find_library(log-lib log)
 add_library(fost-android-java
         fost-android.cpp
         logger.cpp
+        messaging.cpp
         setting.cpp
         view-assets.cpp
         webserver.cpp

--- a/jni/messaging.cpp
+++ b/jni/messaging.cpp
@@ -1,0 +1,58 @@
+/**
+    Copyright 2019 Red Anchor Trading Co. Ltd.
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+ */
+
+
+#include "fost-android.hpp"
+#include "messaging.hpp"
+#include <fost/insert>
+
+
+namespace {
+    /// The registered application that we are sending messages to
+    jobject g_application;
+
+    jclass handler;
+    jmethodID handler_obtainMessage;
+    jmethodID handler_sendMessage;
+
+    const fostlib::jni_onload g_loader([](JNIEnv *env) {
+        handler = reinterpret_cast<jclass>(
+                env->NewGlobalRef(env->FindClass("android/os/Handler")));
+        handler_obtainMessage = env->GetMethodID(
+                handler, "obtainMessage",
+                "(ILjava/lang/Object;)Landroid/os/Message;");
+        handler_sendMessage = env->GetMethodID(
+                handler, "sendMessage", "(Landroid/os/Message;)Z");
+    });
+}
+
+
+bool fostlib::send_message(json const msg) {
+    JNIEnv *env = get_environment();
+
+    jobject payload = env->NewGlobalRef(
+                env->NewStringUTF(fostlib::json::unparse(msg, false).shrink_to_fit()));
+
+    jobject message = env->NewGlobalRef(env->CallObjectMethod(
+            g_application, handler_obtainMessage, 1, payload));
+
+    bool const success = env->CallBooleanMethod(
+        g_application, handler_sendMessage, message);
+
+    return success;
+}
+
+
+/// For naming see <https://stackoverflow.com/a/49560732/115526>
+extern "C" JNIEXPORT void JNICALL Java_com_felspar_android_Messaging_registerApplication(
+    JNIEnv *env, jobject self, jobject app) {
+    g_application = env->NewGlobalRef(app);
+
+    fostlib::json msg;
+    insert(msg, "display", f5::u8view{"Application has been registered"});
+    send_message(msg);
+}

--- a/jni/messaging.hpp
+++ b/jni/messaging.hpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2014-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2019 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>

--- a/jni/messaging.hpp
+++ b/jni/messaging.hpp
@@ -1,0 +1,18 @@
+/**
+    Copyright 2014-2019 Red Anchor Trading Co. Ltd.
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+ */
+
+
+#include <fost/core>
+
+
+namespace fostlib {
+
+
+    bool send_message(fostlib::json);
+
+
+}

--- a/src/com/felspar/android/Messaging.kt
+++ b/src/com/felspar/android/Messaging.kt
@@ -1,0 +1,37 @@
+package com.felspar.android
+
+import android.os.Handler
+import android.os.Message
+import org.json.JSONObject
+
+interface MessageRecipient {
+    fun process(msg : JSONObject)
+}
+internal var application : Messaging? = null
+
+class Messaging(a : MessageRecipient) : Handler() {
+    var app : MessageRecipient;
+
+    init {
+        app = a
+    }
+
+    override fun handleMessage(msg : Message) {
+        if (msg.obj is String) {
+            val raw = msg.obj as String
+            val payload = JSONObject(raw)
+            app.process(payload)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        external fun registerApplication(r : Messaging)
+    }
+}
+
+fun RegisterApplication(r : MessageRecipient) {
+    val msging = Messaging(r)
+    application = msging
+    Messaging.registerApplication(msging)
+}


### PR DESCRIPTION
A new message bus will allow us to send messages to an application from parts of the system (for example from Elm to Android) in order to make the platform perform some task.

This implements the JSON message sending for Anrdoid. The application object must implement the `MessageRecipient` interface. 